### PR TITLE
Replace `eval` with `new Function`

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,18 +398,18 @@ function wrapfunction (fn, message) {
   }
 
   var args = createArgumentsString(fn.length)
-  var deprecate = this // eslint-disable-line no-unused-vars
   var stack = getStack()
   var site = callSiteLocation(stack[1])
 
   site.name = fn.name
 
-   // eslint-disable-next-line no-eval
-  var deprecatedfn = eval('(function (' + args + ') {\n' +
+  // eslint-disable-next-line no-new-func
+  var deprecatedfn = new Function('fn', 'log', 'deprecate', 'message', 'site',
     '"use strict"\n' +
+    'return function (' + args + ') {' +
     'log.call(deprecate, message, site)\n' +
     'return fn.apply(this, arguments)\n' +
-    '})')
+    '}')(fn, log, this, message, site)
 
   return deprecatedfn
 }


### PR DESCRIPTION
Unlike `eval`, code supplied to `new Function` at least does not run in the
local scope. That makes [rollup a lot happier](https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval), although it doesn't make any
difference in this case.