### PR TITLE
Use defineProperty() to avoid eval() and new Function() while preserving arity

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,20 +66,6 @@ function convertDataDescriptorToAccessor (obj, prop, message) {
 }
 
 /**
- * Create arguments string to keep arity.
- */
-
-function createArgumentsString (arity) {
-  var str = ''
-
-  for (var i = 0; i < arity; i++) {
-    str += ', arg' + i
-  }
-
-  return str.substr(2)
-}
-
-/**
  * Create stack string from stack.
  */
 
@@ -398,19 +384,24 @@ function wrapfunction (fn, message) {
     throw new TypeError('argument fn must be a function')
   }
 
-  var args = createArgumentsString(fn.length)
+  var deprecate = this
   var stack = getStack()
   var site = callSiteLocation(stack[1])
 
   site.name = fn.name
 
-  // eslint-disable-next-line no-new-func
-  var deprecatedfn = new Function('fn', 'log', 'deprecate', 'message', 'site',
-    '"use strict"\n' +
-    'return function (' + args + ') {' +
-    'log.call(deprecate, message, site)\n' +
-    'return fn.apply(this, arguments)\n' +
-    '}')(fn, log, this, message, site)
+  var deprecatedfn = function () {
+    log.call(deprecate, message, site)
+    return fn.apply(this, arguments)
+  }
+
+  // Preserve fn's arity.
+  Object.defineProperty(deprecatedfn, 'length', {
+    configurable: true,
+    enumerable: false,
+    value: fn.length,
+    writable: false
+  })
 
   return deprecatedfn
 }


### PR DESCRIPTION
Any thoughts on using `defineProperty(deprecatedfn, 'length', {value: 3, ...})` to preserve arity with a regular function (and thus avoiding `eval()` and new `Function()` entirely)?

Tests pass, and I haven't been able to break it manually. Curious if I've missed any situations where this wouldn't work.