### PR TITLE
Replace function constructor with defineProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,20 +65,6 @@ function convertDataDescriptorToAccessor (obj, prop, message) {
 }
 
 /**
- * Create arguments string to keep arity.
- */
-
-function createArgumentsString (arity) {
-  var str = ''
-
-  for (var i = 0; i < arity; i++) {
-    str += ', arg' + i
-  }
-
-  return str.substr(2)
-}
-
-/**
  * Create stack string from stack.
  */
 
@@ -415,20 +401,17 @@ function wrapfunction (fn, message) {
     throw new TypeError('argument fn must be a function')
   }
 
-  var args = createArgumentsString(fn.length)
+  var deprecate = this
   var stack = getStack()
   var site = callSiteLocation(stack[1])
 
   site.name = fn.name
 
-  // eslint-disable-next-line no-new-func
-  var deprecatedfn = new Function('fn', 'log', 'deprecate', 'message', 'site',
-    '"use strict"\n' +
-    'return function (' + args + ') {' +
-    'log.call(deprecate, message, site)\n' +
-    'return fn.apply(this, arguments)\n' +
-    '}')(fn, log, this, message, site)
-
+  function deprecatedfn () {
+    log.call(deprecate, message, site)
+    return fn.apply(this, arguments)
+  }
+  Object.defineProperty(deprecatedfn, 'length', { value: fn.length })
   return deprecatedfn
 }
 


### PR DESCRIPTION
Resolves #41

Since `defineProperty` is already used extensively in the rest of the code, it seems safe to use it here without a fallback. [`Function.length` is defined with `configurable: true`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length), so this is spec-compliant.

This removes the only occurrence of `eval`ed code (in this case via a function constructor), which makes the project compatible with `--disallow-code-generation-from-strings` as well as `Content-Security-Policy` `script-src` restrictions in the browser. Being able to set these security options allows consumers of this library to create more secure applications through layered security.

This also removes a chunk of code, so the browser bundle size is a little smaller!