### PR TITLE
Add unit test for --disallow-code-generation-from-strings

### DIFF
--- a/test/fixtures/basic.js
+++ b/test/fixtures/basic.js
@@ -1,0 +1,8 @@
+
+var deprecate = require('../..')('basic')
+
+var object = { foo: 'bar' }
+deprecate.property(object, 'foo')
+
+function fn () {}
+deprecate.function(fn)


### PR DESCRIPTION
Alternative testing approach based on discussion in #41

This introduces a failing test for Node 9+. This is separate from the fix so that it can be combined with any of the existing PRs.

I have tested the test with the code from #42 and it passes, as expected.