### PR TITLE
Making callSiteLocation more robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         - io.js 3.x
         - Node.js 4.x
         - Node.js 5.x
+        - Node.js 5.x with core-js polyfill
         - Node.js 6.x
         - Node.js 7.x
         - Node.js 8.x
@@ -62,6 +63,11 @@ jobs:
         - name: Node.js 5.x
           node-version: "5.12"
           npm-i: browserify@15 mocha@5.2.0 nyc@11.9.0
+
+        - name: Node.js 5.x with core-js polyfill
+          node-version: "5.12"
+          npm-i: browserify@15 mocha@5.2.0 nyc@11.9.0 core-js@3
+          ENABLE_COREJS_ERROR_POLYFILL: true
 
         - name: Node.js 6.x
           node-version: "6.17"
@@ -158,6 +164,8 @@ jobs:
 
     - name: Run tests
       shell: bash
+      env:
+        ENABLE_COREJS_ERROR_POLYFILL: ${{ matrix.ENABLE_COREJS_ERROR_POLYFILL }}
       run: |
         if npm -ps ls nyc | grep -q nyc; then
           npm run test-ci

--- a/index.js
+++ b/index.js
@@ -265,9 +265,8 @@ function log (message, site) {
  */
 
 function callSiteLocation (callSite) {
-  var functionName, site
+  var site
   if (callSite) {
-    functionName = callSite.getFunctionName()
     var file = callSite.getFileName() || '<anonymous>'
     var line = callSite.getLineNumber()
     var colm = callSite.getColumnNumber()
@@ -275,15 +274,14 @@ function callSiteLocation (callSite) {
       file = callSite.getEvalOrigin() + ', ' + file
     }
     site = [file, line, colm]
+    site.callSite = callSite
+    site.name = callSite.getFunctionName()
   } else {
-    // eslint-disable-next-line no-param-reassign
-    callSite = {}
-    callSite.getThis = function () { return null }
-    functionName = '<unknown function>'
     site = ['<unknown file>', '<unknown line>', '<unknown column>']
+    site.callSite = {}
+    site.callSite.getThis = function () { return null }
+    site.name = '<unknown function>'
   }
-  site.callSite = callSite
-  site.name = functionName
   return site
 }
 

--- a/index.js
+++ b/index.js
@@ -265,18 +265,18 @@ function log (message, site) {
  */
 
 function callSiteLocation (callSite) {
-  var file = callSite.getFileName() || '<anonymous>'
-  var line = callSite.getLineNumber()
-  var colm = callSite.getColumnNumber()
+  var file = callSite.getFileName ? (callSite.getFileName() || '<anonymous>') : '<unknown file>'
+  var line = callSite.getLineNumber ? callSite.getLineNumber() : '<unknown line number>'
+  var colm = callSite.getColumnNumber ? callSite.getColumnNumber() : '<unknown column number>'
 
-  if (callSite.isEval()) {
+  if (callSite.isEval && callSite.isEval()) {
     file = callSite.getEvalOrigin() + ', ' + file
   }
 
   var site = [file, line, colm]
 
   site.callSite = callSite
-  site.name = callSite.getFunctionName()
+  site.name = callSite.getFunctionName ? callSite.getFunctionName() : '<unknown function>'
 
   return site
 }

--- a/test/test.js
+++ b/test/test.js
@@ -27,30 +27,30 @@ describe('depd(namespace)', function () {
 describe('deprecate(message)', function () {
   it('should log namespace', function () {
     function callold () { mylib.old() }
-    assert.ok(captureStderr(callold).indexOf('my-lib') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf('my-lib'), -1)
   })
 
   it('should log deprecation', function () {
     function callold () { mylib.old() }
-    assert.ok(captureStderr(callold).indexOf('deprecate') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf('deprecate'), -1)
   })
 
   it('should log message', function () {
     function callold () { mylib.old() }
-    assert.ok(captureStderr(callold).indexOf('old') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf('old'), -1)
   })
 
   it('should log call site', function () {
     function callold () { mylib.old() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should log call site from strict lib', function () {
     function callold () { strictlib.old() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -60,7 +60,7 @@ describe('deprecate(message)', function () {
     try {
       Error.stackTraceLimit = 1
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     } finally {
       Error.stackTraceLimit = limit
@@ -70,15 +70,15 @@ describe('deprecate(message)', function () {
   it('should log call site within eval', function () {
     function callold () { eval('mylib.old()') } // eslint-disable-line no-eval
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-    assert.ok(stderr.indexOf('<anonymous>:1:') !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+    assert.notStrictEqual(stderr.indexOf('<anonymous>:1:'), -1)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should log call site within strict', function () {
     function callold () { 'use strict'; mylib.old() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -103,10 +103,10 @@ describe('deprecate(message)', function () {
     }
 
     prop = 'old'
-    assert.ok(captureStderr(callold).indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(basename(__filename)), -1)
 
     prop = 'old2'
-    assert.ok(captureStderr(callold).indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(basename(__filename)), -1)
   })
 
   it('should warn for different calls on same line', function () {
@@ -116,7 +116,7 @@ describe('deprecate(message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -125,9 +125,9 @@ describe('deprecate(message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { mylib.automsgnamed() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' automsgnamed ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
     })
 
     it('should generate message for function call on named function', function () {
@@ -136,17 +136,17 @@ describe('deprecate(message)', function () {
         fn()
       }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' automsgnamed ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
     })
 
     it('should generate message for method call on unnamed function', function () {
       function callold () { mylib.automsg() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' exports.automsg ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
     })
 
     it('should generate message for function call on unnamed function', function () {
@@ -155,16 +155,16 @@ describe('deprecate(message)', function () {
         fn()
       }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' exports.automsg ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
     })
 
     it('should generate message for function call on anonymous function', function () {
       function callold () { mylib.automsganon() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
       assert.ok(/ exports\.automsganon | <anonymous@[^\\/]+[^:]+:[0-9]+:[0-9]+> /.test(stderr))
     })
 
@@ -172,9 +172,9 @@ describe('deprecate(message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { strictlib.automsgnamed() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' automsgnamed ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
       })
 
       it('should generate message for function call on named function', function () {
@@ -183,17 +183,17 @@ describe('deprecate(message)', function () {
           fn()
         }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' automsgnamed ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
       })
 
       it('should generate message for method call on unnamed function', function () {
         function callold () { strictlib.automsg() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' exports.automsg ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
       })
 
       it('should generate message for function call on unnamed function', function () {
@@ -202,16 +202,16 @@ describe('deprecate(message)', function () {
           fn()
         }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' exports.automsg ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
       })
 
       it('should generate message for function call on anonymous function', function () {
         function callold () { strictlib.automsganon() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
         assert.ok(/ exports\.automsganon | <anonymous@[^\\/]+[^:]+:[0-9]+:[0-9]+> /.test(stderr))
       })
     })
@@ -226,23 +226,23 @@ describe('deprecate(message)', function () {
 
     it('should log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.ok(stderr.indexOf('\x1b[') !== -1)
+      assert.notStrictEqual(stderr.indexOf('\x1b['), -1)
     })
 
     it('should log namespace', function () {
-      assert.ok(stderr.indexOf('my-lib') !== -1)
+      assert.notStrictEqual(stderr.indexOf('my-lib'), -1)
     })
 
     it('should log deprecation', function () {
-      assert.ok(stderr.indexOf('deprecate') !== -1)
+      assert.notStrictEqual(stderr.indexOf('deprecate'), -1)
     })
 
     it('should log message', function () {
-      assert.ok(stderr.indexOf('old') !== -1)
+      assert.notStrictEqual(stderr.indexOf('old'), -1)
     })
 
     it('should log call site', function () {
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     })
   })
@@ -256,11 +256,11 @@ describe('deprecate(message)', function () {
 
     it('should not log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.ok(stderr.indexOf('\x1b[') === -1)
+      assert.strictEqual(stderr.indexOf('\x1b['), -1)
     })
 
     it('should log namespace', function () {
-      assert.ok(stderr.indexOf('my-lib') !== -1)
+      assert.notStrictEqual(stderr.indexOf('my-lib'), -1)
     })
 
     it('should log timestamp', function () {
@@ -268,15 +268,15 @@ describe('deprecate(message)', function () {
     })
 
     it('should log deprecation', function () {
-      assert.ok(stderr.indexOf('deprecate') !== -1)
+      assert.notStrictEqual(stderr.indexOf('deprecate'), -1)
     })
 
     it('should log message', function () {
-      assert.ok(stderr.indexOf('old') !== -1)
+      assert.notStrictEqual(stderr.indexOf('old'), -1)
     })
 
     it('should log call site', function () {
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     })
   })
@@ -290,7 +290,7 @@ describe('deprecate.function(fn, message)', function () {
 
   it('should log on call to function', function () {
     function callold () { mylib.oldfn() }
-    assert.ok(captureStderr(callold).indexOf(' oldfn ') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(' oldfn '), -1)
   })
 
   it('should have same arity', function () {
@@ -300,21 +300,21 @@ describe('deprecate.function(fn, message)', function () {
   it('should pass arguments', function () {
     var ret
     function callold () { ret = mylib.oldfn(1, 2) }
-    assert.ok(captureStderr(callold).indexOf(' oldfn ') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(' oldfn '), -1)
     assert.strictEqual(ret, 2)
   })
 
   it('should show call site outside scope', function () {
     function callold () { mylib.layerfn() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(' oldfn ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should show call site outside scope from strict lib', function () {
     function callold () { strictlib.layerfn() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(' oldfn ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -351,7 +351,7 @@ describe('deprecate.function(fn, message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -360,17 +360,17 @@ describe('deprecate.function(fn, message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { mylib.oldfnauto() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' fn ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' fn '), -1)
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
 
     it('should generate message for method call on anonymous function', function () {
       function callold () { mylib.oldfnautoanon() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
       assert.ok(/ <anonymous@[^\\/]+[^:]+my\.js:[0-9]+:[0-9]+> /.test(stderr))
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
@@ -379,17 +379,17 @@ describe('deprecate.function(fn, message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { strictlib.oldfnauto() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' fn ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' fn '), -1)
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
 
       it('should generate message for method call on anonymous function', function () {
         function callold () { strictlib.oldfnautoanon() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
         assert.ok(/ <anonymous@[^\\/]+[^:]+strict\.js:[0-9]+:[0-9]+> /.test(stderr))
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
@@ -419,8 +419,8 @@ describe('deprecate.property(obj, prop, message)', function () {
   it('should log on access to property', function () {
     function callprop () { return mylib.propa }
     var stderr = captureStderr(callprop)
-    assert.ok(stderr.indexOf(' deprecated ') !== -1)
-    assert.ok(stderr.indexOf(' propa gone ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+    assert.notStrictEqual(stderr.indexOf(' propa gone '), -1)
   })
 
   it('should log on setting property', function () {
@@ -428,9 +428,9 @@ describe('deprecate.property(obj, prop, message)', function () {
     function callprop () { val = mylib.propa }
     function setprop () { mylib.propa = 'newval' }
     var stderr = captureStderr(setprop)
-    assert.ok(stderr.indexOf(' deprecated ') !== -1)
-    assert.ok(stderr.indexOf(' propa gone ') !== -1)
-    assert.ok(captureStderr(callprop).indexOf(' deprecated ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+    assert.notStrictEqual(stderr.indexOf(' propa gone '), -1)
+    assert.notStrictEqual(captureStderr(callprop).indexOf(' deprecated '), -1)
     assert.strictEqual(val, 'newval')
   })
 
@@ -454,7 +454,7 @@ describe('deprecate.property(obj, prop, message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -462,14 +462,14 @@ describe('deprecate.property(obj, prop, message)', function () {
   it('should show call site outside scope', function () {
     function callold () { mylib.layerprop() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(' propa ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' propa '), -1)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should show call site outside scope from strict lib', function () {
     function callold () { strictlib.layerprop() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(' propa ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' propa '), -1)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -477,30 +477,30 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access to property on function', function () {
       function callprop () { return mylib.fnprop.propa }
       var stderr = captureStderr(callprop)
-      assert.ok(stderr.indexOf(' deprecated ') !== -1)
-      assert.ok(stderr.indexOf(' fn propa gone ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+      assert.notStrictEqual(stderr.indexOf(' fn propa gone '), -1)
     })
 
     it('should generate message on named function', function () {
       function callprop () { return mylib.fnprop.propautomsg }
       var stderr = captureStderr(callprop)
-      assert.ok(stderr.indexOf(' deprecated ') !== -1)
-      assert.ok(stderr.indexOf(' thefn.propautomsg ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+      assert.notStrictEqual(stderr.indexOf(' thefn.propautomsg '), -1)
     })
 
     describe('in strict mode library', function () {
       it('should log on access to property on function', function () {
         function callprop () { return strictlib.fnprop.propa }
         var stderr = captureStderr(callprop)
-        assert.ok(stderr.indexOf(' deprecated ') !== -1)
-        assert.ok(stderr.indexOf(' fn propa gone ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+        assert.notStrictEqual(stderr.indexOf(' fn propa gone '), -1)
       })
 
       it('should generate message on named function', function () {
         function callprop () { return strictlib.fnprop.propautomsg }
         var stderr = captureStderr(callprop)
-        assert.ok(stderr.indexOf(' deprecated ') !== -1)
-        assert.ok(stderr.indexOf(' thefn.propautomsg ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+        assert.notStrictEqual(stderr.indexOf(' thefn.propautomsg '), -1)
       })
     })
   })
@@ -509,14 +509,14 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access and set', function () {
       function callold () { return mylib.propa }
       function setold () { mylib.propa = 'val' }
-      assert.ok(captureStderr(callold).indexOf(' deprecated ') !== -1)
-      assert.ok(captureStderr(setold).indexOf(' deprecated ') !== -1)
+      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
+      assert.notStrictEqual(captureStderr(setold).indexOf(' deprecated '), -1)
     })
 
     it('should not log on set to non-writable', function () {
       function callold () { return mylib.propget }
       function setold () { mylib.propget = 'val' }
-      assert.ok(captureStderr(callold).indexOf(' deprecated ') !== -1)
+      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
       assert.strictEqual(captureStderr(setold), '')
     })
   })
@@ -525,8 +525,8 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access and set', function () {
       function callold () { return mylib.propdyn }
       function setold () { mylib.propdyn = 'val' }
-      assert.ok(captureStderr(callold).indexOf(' deprecated ') !== -1)
-      assert.ok(captureStderr(setold).indexOf(' deprecated ') !== -1)
+      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
+      assert.notStrictEqual(captureStderr(setold).indexOf(' deprecated '), -1)
     })
 
     it('should not log on access when no accessor', function () {
@@ -544,9 +544,9 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { return mylib.propauto }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' propauto ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' propauto '), -1)
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
 
@@ -554,9 +554,9 @@ describe('deprecate.property(obj, prop, message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { return strictlib.propauto }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' propauto ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' propauto '), -1)
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
     })
@@ -687,13 +687,13 @@ describe('process.env.TRACE_DEPRECATION', function () {
   it('should trace given namespace', function () {
     var tracelib = libs.trace
     function callold () { tracelib.old() }
-    assert.ok(captureStderr(callold).indexOf(' trace-lib deprecated old\n    at callold (') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(' trace-lib deprecated old\n    at callold ('), -1)
   })
 
   it('should not trace non-given namespace', function () {
     var tracelib = libs.trace
     function callold () { tracelib.old2() }
-    assert.ok(captureStderr(callold).indexOf(' trace-lib-other deprecated old2 at ') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(' trace-lib-other deprecated old2 at '), -1)
   })
 
   describe('when output supports colors', function () {
@@ -706,15 +706,15 @@ describe('process.env.TRACE_DEPRECATION', function () {
 
     it('should log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.ok(stderr.indexOf('\x1b[') !== -1)
+      assert.notStrictEqual(stderr.indexOf('\x1b['), -1)
     })
 
     it('should log namespace', function () {
-      assert.ok(stderr.indexOf('trace-lib') !== -1)
+      assert.notStrictEqual(stderr.indexOf('trace-lib'), -1)
     })
 
     it('should log call site in color', function () {
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
       assert.ok(/\x1b\[\d+mat callold \(/.test(stderr)) // eslint-disable-line no-control-regex
     })
   })
@@ -752,7 +752,7 @@ describe('node script.js', function () {
     it('should suppress deprecation message', function (done) {
       captureChildStderr(script, ['--trace-deprecation'], function (err, stderr) {
         if (err) return done(err)
-        assert.ok(stderr.indexOf('__timestamp__ my-cool-module deprecated oldfunction\n    at run (' + script + ':7:10)\n    at') === 0)
+        assert.strictEqual(stderr.indexOf('__timestamp__ my-cool-module deprecated oldfunction\n    at run (' + script + ':7:10)\n    at'), 0)
         done()
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,10 @@ var script = path.join(__dirname, 'fixtures', 'script.js')
 var spawn = require('child_process').spawn
 var strictlib = libs.strict
 
+if (process.env.ENABLE_COREJS_ERROR_POLYFILL) { // cf. PR #48
+  require('core-js/modules/es.error.cause')
+}
+
 describe('depd(namespace)', function () {
   it('creates deprecated function', function () {
     assert.strictEqual(typeof depd('test'), 'function')


### PR DESCRIPTION
Hi

We had several issues when using the `body-parser` lib, that itself uses `depd`, under NodeJS 5:

```
TypeError: callSite.getFileName is not a function
    at callSiteLocation (C:\nodejs-depd-bug-repro\dist\bundle.js:452:3231)
    at depd (C:\nodejs-depd-bug-repro\dist\bundle.js:452:1375)
    at node_modulesBodyParserIndexJs (C:\nodejs-depd-bug-repro\dist\bundle.js:508:172)
    at __require (C:\nodejs-depd-bug-repro\dist\bundle.js:1:8616)
    at Object.<anonymous> (C:\nodejs-depd-bug-repro\dist\bundle.js:509:68)
```

This patch makes sure that `callSiteLocation` never crashes, even when some underlying methods do not exist or its `callSite` argument does not have the expected object type (it was `String` in some cases we investigated).