### PR TITLE
Improving test assertions

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -23,30 +23,33 @@ describe('depd(namespace)', function () {
 describe('deprecate(message)', function () {
   it('should log namespace', function () {
     function callold () { mylib.old() }
-    assert.notStrictEqual(captureStderr(callold).indexOf('my-lib'), -1)
+    var stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf('my-lib'), -1, stderr)
   })
 
   it('should log deprecation', function () {
     function callold () { mylib.old() }
-    assert.notStrictEqual(captureStderr(callold).indexOf('deprecate'), -1)
+    var stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf('deprecate'), -1, stderr)
   })
 
   it('should log message', function () {
     function callold () { mylib.old() }
-    assert.notStrictEqual(captureStderr(callold).indexOf('old'), -1)
+    var stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf('old'), -1, stderr)
   })
 
   it('should log call site', function () {
     function callold () { mylib.old() }
     var stderr = captureStderr(callold)
-    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should log call site from strict lib', function () {
     function callold () { strictlib.old() }
     var stderr = captureStderr(callold)
-    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -56,7 +59,7 @@ describe('deprecate(message)', function () {
     try {
       Error.stackTraceLimit = 1
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     } finally {
       Error.stackTraceLimit = limit
@@ -66,15 +69,15 @@ describe('deprecate(message)', function () {
   it('should log call site within eval', function () {
     function callold () { eval('mylib.old()') } // eslint-disable-line no-eval
     var stderr = captureStderr(callold)
-    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-    assert.notStrictEqual(stderr.indexOf('<anonymous>:1:'), -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+    assert.notStrictEqual(stderr.indexOf('<anonymous>:1:'), -1, stderr)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should log call site within strict', function () {
     function callold () { 'use strict'; mylib.old() }
     var stderr = captureStderr(callold)
-    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -92,17 +95,19 @@ describe('deprecate(message)', function () {
   })
 
   it('should warn for different fns on same call site', function () {
-    var prop
+    var prop, stderr
 
     function callold () {
       mylib[prop]() // call from same site
     }
 
     prop = 'old'
-    assert.notStrictEqual(captureStderr(callold).indexOf(basename(__filename)), -1)
+    stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
 
     prop = 'old2'
-    assert.notStrictEqual(captureStderr(callold).indexOf(basename(__filename)), -1)
+    stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
   })
 
   it('should warn for different calls on same line', function () {
@@ -112,7 +117,7 @@ describe('deprecate(message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -121,9 +126,9 @@ describe('deprecate(message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { mylib.automsgnamed() }
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-      assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1, stderr)
     })
 
     it('should generate message for function call on named function', function () {
@@ -132,17 +137,17 @@ describe('deprecate(message)', function () {
         fn()
       }
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-      assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1, stderr)
     })
 
     it('should generate message for method call on unnamed function', function () {
       function callold () { mylib.automsg() }
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-      assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1, stderr)
     })
 
     it('should generate message for function call on unnamed function', function () {
@@ -151,16 +156,16 @@ describe('deprecate(message)', function () {
         fn()
       }
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-      assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1, stderr)
     })
 
     it('should generate message for function call on anonymous function', function () {
       function callold () { mylib.automsganon() }
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
       assert.ok(/ exports\.automsganon | <anonymous@[^\\/]+[^:]+:[0-9]+:[0-9]+> /.test(stderr))
     })
 
@@ -168,9 +173,9 @@ describe('deprecate(message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { strictlib.automsgnamed() }
         var stderr = captureStderr(callold)
-        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-        assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1, stderr)
       })
 
       it('should generate message for function call on named function', function () {
@@ -179,17 +184,17 @@ describe('deprecate(message)', function () {
           fn()
         }
         var stderr = captureStderr(callold)
-        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-        assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1, stderr)
       })
 
       it('should generate message for method call on unnamed function', function () {
         function callold () { strictlib.automsg() }
         var stderr = captureStderr(callold)
-        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-        assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1, stderr)
       })
 
       it('should generate message for function call on unnamed function', function () {
@@ -198,16 +203,16 @@ describe('deprecate(message)', function () {
           fn()
         }
         var stderr = captureStderr(callold)
-        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-        assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1, stderr)
       })
 
       it('should generate message for function call on anonymous function', function () {
         function callold () { strictlib.automsganon() }
         var stderr = captureStderr(callold)
-        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
         assert.ok(/ exports\.automsganon | <anonymous@[^\\/]+[^:]+:[0-9]+:[0-9]+> /.test(stderr))
       })
     })
@@ -222,23 +227,23 @@ describe('deprecate(message)', function () {
 
     it('should log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.notStrictEqual(stderr.indexOf('\x1b['), -1)
+      assert.notStrictEqual(stderr.indexOf('\x1b['), -1, stderr)
     })
 
     it('should log namespace', function () {
-      assert.notStrictEqual(stderr.indexOf('my-lib'), -1)
+      assert.notStrictEqual(stderr.indexOf('my-lib'), -1, stderr)
     })
 
     it('should log deprecation', function () {
-      assert.notStrictEqual(stderr.indexOf('deprecate'), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecate'), -1, stderr)
     })
 
     it('should log message', function () {
-      assert.notStrictEqual(stderr.indexOf('old'), -1)
+      assert.notStrictEqual(stderr.indexOf('old'), -1, stderr)
     })
 
     it('should log call site', function () {
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     })
   })
@@ -252,11 +257,11 @@ describe('deprecate(message)', function () {
 
     it('should not log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.strictEqual(stderr.indexOf('\x1b['), -1)
+      assert.strictEqual(stderr.indexOf('\x1b['), -1, stderr)
     })
 
     it('should log namespace', function () {
-      assert.notStrictEqual(stderr.indexOf('my-lib'), -1)
+      assert.notStrictEqual(stderr.indexOf('my-lib'), -1, stderr)
     })
 
     it('should log timestamp', function () {
@@ -264,15 +269,15 @@ describe('deprecate(message)', function () {
     })
 
     it('should log deprecation', function () {
-      assert.notStrictEqual(stderr.indexOf('deprecate'), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecate'), -1, stderr)
     })
 
     it('should log message', function () {
-      assert.notStrictEqual(stderr.indexOf('old'), -1)
+      assert.notStrictEqual(stderr.indexOf('old'), -1, stderr)
     })
 
     it('should log call site', function () {
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     })
   })
@@ -286,7 +291,8 @@ describe('deprecate.function(fn, message)', function () {
 
   it('should log on call to function', function () {
     function callold () { mylib.oldfn() }
-    assert.notStrictEqual(captureStderr(callold).indexOf(' oldfn '), -1)
+    var stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1, stderr)
   })
 
   it('should have same arity', function () {
@@ -296,21 +302,22 @@ describe('deprecate.function(fn, message)', function () {
   it('should pass arguments', function () {
     var ret
     function callold () { ret = mylib.oldfn(1, 2) }
-    assert.notStrictEqual(captureStderr(callold).indexOf(' oldfn '), -1)
+    var stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1, stderr)
     assert.strictEqual(ret, 2)
   })
 
   it('should show call site outside scope', function () {
     function callold () { mylib.layerfn() }
     var stderr = captureStderr(callold)
-    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1)
+    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1, stderr)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should show call site outside scope from strict lib', function () {
     function callold () { strictlib.layerfn() }
     var stderr = captureStderr(callold)
-    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1)
+    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1, stderr)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -347,7 +354,7 @@ describe('deprecate.function(fn, message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -356,17 +363,17 @@ describe('deprecate.function(fn, message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { mylib.oldfnauto() }
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-      assert.notStrictEqual(stderr.indexOf(' fn '), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf(' fn '), -1, stderr)
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
 
     it('should generate message for method call on anonymous function', function () {
       function callold () { mylib.oldfnautoanon() }
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
       assert.ok(/ <anonymous@[^\\/]+[^:]+my\.js:[0-9]+:[0-9]+> /.test(stderr))
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
@@ -375,17 +382,17 @@ describe('deprecate.function(fn, message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { strictlib.oldfnauto() }
         var stderr = captureStderr(callold)
-        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-        assert.notStrictEqual(stderr.indexOf(' fn '), -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf(' fn '), -1, stderr)
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
 
       it('should generate message for method call on anonymous function', function () {
         function callold () { strictlib.oldfnautoanon() }
         var stderr = captureStderr(callold)
-        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
         assert.ok(/ <anonymous@[^\\/]+[^:]+strict\.js:[0-9]+:[0-9]+> /.test(stderr))
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
@@ -415,8 +422,8 @@ describe('deprecate.property(obj, prop, message)', function () {
   it('should log on access to property', function () {
     function callprop () { return mylib.propa }
     var stderr = captureStderr(callprop)
-    assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
-    assert.notStrictEqual(stderr.indexOf(' propa gone '), -1)
+    assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+    assert.notStrictEqual(stderr.indexOf(' propa gone '), -1, stderr)
   })
 
   it('should log on setting property', function () {
@@ -424,9 +431,9 @@ describe('deprecate.property(obj, prop, message)', function () {
     function callprop () { val = mylib.propa }
     function setprop () { mylib.propa = 'newval' }
     var stderr = captureStderr(setprop)
-    assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
-    assert.notStrictEqual(stderr.indexOf(' propa gone '), -1)
-    assert.notStrictEqual(captureStderr(callprop).indexOf(' deprecated '), -1)
+    assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+    assert.notStrictEqual(stderr.indexOf(' propa gone '), -1, stderr)
+    assert.notStrictEqual(captureStderr(callprop).indexOf(' deprecated '), -1, stderr)
     assert.strictEqual(val, 'newval')
   })
 
@@ -450,7 +457,7 @@ describe('deprecate.property(obj, prop, message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -458,14 +465,14 @@ describe('deprecate.property(obj, prop, message)', function () {
   it('should show call site outside scope', function () {
     function callold () { mylib.layerprop() }
     var stderr = captureStderr(callold)
-    assert.notStrictEqual(stderr.indexOf(' propa '), -1)
+    assert.notStrictEqual(stderr.indexOf(' propa '), -1, stderr)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should show call site outside scope from strict lib', function () {
     function callold () { strictlib.layerprop() }
     var stderr = captureStderr(callold)
-    assert.notStrictEqual(stderr.indexOf(' propa '), -1)
+    assert.notStrictEqual(stderr.indexOf(' propa '), -1, stderr)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -473,30 +480,30 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access to property on function', function () {
       function callprop () { return mylib.fnprop.propa }
       var stderr = captureStderr(callprop)
-      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
-      assert.notStrictEqual(stderr.indexOf(' fn propa gone '), -1)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf(' fn propa gone '), -1, stderr)
     })
 
     it('should generate message on named function', function () {
       function callprop () { return mylib.fnprop.propautomsg }
       var stderr = captureStderr(callprop)
-      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
-      assert.notStrictEqual(stderr.indexOf(' thefn.propautomsg '), -1)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf(' thefn.propautomsg '), -1, stderr)
     })
 
     describe('in strict mode library', function () {
       it('should log on access to property on function', function () {
         function callprop () { return strictlib.fnprop.propa }
         var stderr = captureStderr(callprop)
-        assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
-        assert.notStrictEqual(stderr.indexOf(' fn propa gone '), -1)
+        assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf(' fn propa gone '), -1, stderr)
       })
 
       it('should generate message on named function', function () {
         function callprop () { return strictlib.fnprop.propautomsg }
         var stderr = captureStderr(callprop)
-        assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
-        assert.notStrictEqual(stderr.indexOf(' thefn.propautomsg '), -1)
+        assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf(' thefn.propautomsg '), -1, stderr)
       })
     })
   })
@@ -505,15 +512,19 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access and set', function () {
       function callold () { return mylib.propa }
       function setold () { mylib.propa = 'val' }
-      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
-      assert.notStrictEqual(captureStderr(setold).indexOf(' deprecated '), -1)
+      var stderr = captureStderr(callold)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+      stderr = captureStderr(setold)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
     })
 
     it('should not log on set to non-writable', function () {
       function callold () { return mylib.propget }
       function setold () { mylib.propget = 'val' }
-      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
-      assert.strictEqual(captureStderr(setold), '')
+      var stderr = captureStderr(callold)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+      stderr = captureStderr(setold)
+      assert.strictEqual(stderr, '')
     })
   })
 
@@ -521,8 +532,10 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access and set', function () {
       function callold () { return mylib.propdyn }
       function setold () { mylib.propdyn = 'val' }
-      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
-      assert.notStrictEqual(captureStderr(setold).indexOf(' deprecated '), -1)
+      var stderr = captureStderr(callold)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
+      stderr = captureStderr(setold)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1, stderr)
     })
 
     it('should not log on access when no accessor', function () {
@@ -540,9 +553,9 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { return mylib.propauto }
       var stderr = captureStderr(callold)
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-      assert.notStrictEqual(stderr.indexOf(' propauto '), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+      assert.notStrictEqual(stderr.indexOf(' propauto '), -1, stderr)
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
 
@@ -550,9 +563,9 @@ describe('deprecate.property(obj, prop, message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { return strictlib.propauto }
         var stderr = captureStderr(callold)
-        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
-        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
-        assert.notStrictEqual(stderr.indexOf(' propauto '), -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1, stderr)
+        assert.notStrictEqual(stderr.indexOf(' propauto '), -1, stderr)
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
     })
@@ -683,13 +696,15 @@ describe('process.env.TRACE_DEPRECATION', function () {
   it('should trace given namespace', function () {
     var tracelib = libs.trace
     function callold () { tracelib.old() }
-    assert.notStrictEqual(captureStderr(callold).indexOf(' trace-lib deprecated old\n    at callold ('), -1)
+    var stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf(' trace-lib deprecated old\n    at callold ('), -1, stderr)
   })
 
   it('should not trace non-given namespace', function () {
     var tracelib = libs.trace
     function callold () { tracelib.old2() }
-    assert.notStrictEqual(captureStderr(callold).indexOf(' trace-lib-other deprecated old2 at '), -1)
+    var stderr = captureStderr(callold)
+    assert.notStrictEqual(stderr.indexOf(' trace-lib-other deprecated old2 at '), -1, stderr)
   })
 
   describe('when output supports colors', function () {
@@ -702,15 +717,15 @@ describe('process.env.TRACE_DEPRECATION', function () {
 
     it('should log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.notStrictEqual(stderr.indexOf('\x1b['), -1)
+      assert.notStrictEqual(stderr.indexOf('\x1b['), -1, stderr)
     })
 
     it('should log namespace', function () {
-      assert.notStrictEqual(stderr.indexOf('trace-lib'), -1)
+      assert.notStrictEqual(stderr.indexOf('trace-lib'), -1, stderr)
     })
 
     it('should log call site in color', function () {
-      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1, stderr)
       assert.ok(/\x1b\[\d+mat callold \(/.test(stderr)) // eslint-disable-line no-control-regex
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -23,30 +23,30 @@ describe('depd(namespace)', function () {
 describe('deprecate(message)', function () {
   it('should log namespace', function () {
     function callold () { mylib.old() }
-    assert.ok(captureStderr(callold).indexOf('my-lib') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf('my-lib'), -1)
   })
 
   it('should log deprecation', function () {
     function callold () { mylib.old() }
-    assert.ok(captureStderr(callold).indexOf('deprecate') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf('deprecate'), -1)
   })
 
   it('should log message', function () {
     function callold () { mylib.old() }
-    assert.ok(captureStderr(callold).indexOf('old') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf('old'), -1)
   })
 
   it('should log call site', function () {
     function callold () { mylib.old() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should log call site from strict lib', function () {
     function callold () { strictlib.old() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -56,7 +56,7 @@ describe('deprecate(message)', function () {
     try {
       Error.stackTraceLimit = 1
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     } finally {
       Error.stackTraceLimit = limit
@@ -66,15 +66,15 @@ describe('deprecate(message)', function () {
   it('should log call site within eval', function () {
     function callold () { eval('mylib.old()') } // eslint-disable-line no-eval
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-    assert.ok(stderr.indexOf('<anonymous>:1:') !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+    assert.notStrictEqual(stderr.indexOf('<anonymous>:1:'), -1)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should log call site within strict', function () {
     function callold () { 'use strict'; mylib.old() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -99,10 +99,10 @@ describe('deprecate(message)', function () {
     }
 
     prop = 'old'
-    assert.ok(captureStderr(callold).indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(basename(__filename)), -1)
 
     prop = 'old2'
-    assert.ok(captureStderr(callold).indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(basename(__filename)), -1)
   })
 
   it('should warn for different calls on same line', function () {
@@ -112,7 +112,7 @@ describe('deprecate(message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -121,9 +121,9 @@ describe('deprecate(message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { mylib.automsgnamed() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' automsgnamed ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
     })
 
     it('should generate message for function call on named function', function () {
@@ -132,17 +132,17 @@ describe('deprecate(message)', function () {
         fn()
       }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' automsgnamed ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
     })
 
     it('should generate message for method call on unnamed function', function () {
       function callold () { mylib.automsg() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' exports.automsg ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
     })
 
     it('should generate message for function call on unnamed function', function () {
@@ -151,16 +151,16 @@ describe('deprecate(message)', function () {
         fn()
       }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' exports.automsg ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
     })
 
     it('should generate message for function call on anonymous function', function () {
       function callold () { mylib.automsganon() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
       assert.ok(/ exports\.automsganon | <anonymous@[^\\/]+[^:]+:[0-9]+:[0-9]+> /.test(stderr))
     })
 
@@ -168,9 +168,9 @@ describe('deprecate(message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { strictlib.automsgnamed() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' automsgnamed ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
       })
 
       it('should generate message for function call on named function', function () {
@@ -179,17 +179,17 @@ describe('deprecate(message)', function () {
           fn()
         }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' automsgnamed ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' automsgnamed '), -1)
       })
 
       it('should generate message for method call on unnamed function', function () {
         function callold () { strictlib.automsg() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' exports.automsg ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
       })
 
       it('should generate message for function call on unnamed function', function () {
@@ -198,16 +198,16 @@ describe('deprecate(message)', function () {
           fn()
         }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' exports.automsg ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' exports.automsg '), -1)
       })
 
       it('should generate message for function call on anonymous function', function () {
         function callold () { strictlib.automsganon() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
         assert.ok(/ exports\.automsganon | <anonymous@[^\\/]+[^:]+:[0-9]+:[0-9]+> /.test(stderr))
       })
     })
@@ -222,23 +222,23 @@ describe('deprecate(message)', function () {
 
     it('should log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.ok(stderr.indexOf('\x1b[') !== -1)
+      assert.notStrictEqual(stderr.indexOf('\x1b['), -1)
     })
 
     it('should log namespace', function () {
-      assert.ok(stderr.indexOf('my-lib') !== -1)
+      assert.notStrictEqual(stderr.indexOf('my-lib'), -1)
     })
 
     it('should log deprecation', function () {
-      assert.ok(stderr.indexOf('deprecate') !== -1)
+      assert.notStrictEqual(stderr.indexOf('deprecate'), -1)
     })
 
     it('should log message', function () {
-      assert.ok(stderr.indexOf('old') !== -1)
+      assert.notStrictEqual(stderr.indexOf('old'), -1)
     })
 
     it('should log call site', function () {
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     })
   })
@@ -252,11 +252,11 @@ describe('deprecate(message)', function () {
 
     it('should not log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.ok(stderr.indexOf('\x1b[') === -1)
+      assert.strictEqual(stderr.indexOf('\x1b['), -1)
     })
 
     it('should log namespace', function () {
-      assert.ok(stderr.indexOf('my-lib') !== -1)
+      assert.notStrictEqual(stderr.indexOf('my-lib'), -1)
     })
 
     it('should log timestamp', function () {
@@ -264,15 +264,15 @@ describe('deprecate(message)', function () {
     })
 
     it('should log deprecation', function () {
-      assert.ok(stderr.indexOf('deprecate') !== -1)
+      assert.notStrictEqual(stderr.indexOf('deprecate'), -1)
     })
 
     it('should log message', function () {
-      assert.ok(stderr.indexOf('old') !== -1)
+      assert.notStrictEqual(stderr.indexOf('old'), -1)
     })
 
     it('should log call site', function () {
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
       assert.ok(/\.js:[0-9]+:[0-9]+/.test(stderr))
     })
   })
@@ -286,7 +286,7 @@ describe('deprecate.function(fn, message)', function () {
 
   it('should log on call to function', function () {
     function callold () { mylib.oldfn() }
-    assert.ok(captureStderr(callold).indexOf(' oldfn ') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(' oldfn '), -1)
   })
 
   it('should have same arity', function () {
@@ -296,21 +296,21 @@ describe('deprecate.function(fn, message)', function () {
   it('should pass arguments', function () {
     var ret
     function callold () { ret = mylib.oldfn(1, 2) }
-    assert.ok(captureStderr(callold).indexOf(' oldfn ') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(' oldfn '), -1)
     assert.strictEqual(ret, 2)
   })
 
   it('should show call site outside scope', function () {
     function callold () { mylib.layerfn() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(' oldfn ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should show call site outside scope from strict lib', function () {
     function callold () { strictlib.layerfn() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(' oldfn ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' oldfn '), -1)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -347,7 +347,7 @@ describe('deprecate.function(fn, message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -356,17 +356,17 @@ describe('deprecate.function(fn, message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { mylib.oldfnauto() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' fn ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' fn '), -1)
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
 
     it('should generate message for method call on anonymous function', function () {
       function callold () { mylib.oldfnautoanon() }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
       assert.ok(/ <anonymous@[^\\/]+[^:]+my\.js:[0-9]+:[0-9]+> /.test(stderr))
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
@@ -375,17 +375,17 @@ describe('deprecate.function(fn, message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { strictlib.oldfnauto() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' fn ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' fn '), -1)
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
 
       it('should generate message for method call on anonymous function', function () {
         function callold () { strictlib.oldfnautoanon() }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
         assert.ok(/ <anonymous@[^\\/]+[^:]+strict\.js:[0-9]+:[0-9]+> /.test(stderr))
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
@@ -415,8 +415,8 @@ describe('deprecate.property(obj, prop, message)', function () {
   it('should log on access to property', function () {
     function callprop () { return mylib.propa }
     var stderr = captureStderr(callprop)
-    assert.ok(stderr.indexOf(' deprecated ') !== -1)
-    assert.ok(stderr.indexOf(' propa gone ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+    assert.notStrictEqual(stderr.indexOf(' propa gone '), -1)
   })
 
   it('should log on setting property', function () {
@@ -424,9 +424,9 @@ describe('deprecate.property(obj, prop, message)', function () {
     function callprop () { val = mylib.propa }
     function setprop () { mylib.propa = 'newval' }
     var stderr = captureStderr(setprop)
-    assert.ok(stderr.indexOf(' deprecated ') !== -1)
-    assert.ok(stderr.indexOf(' propa gone ') !== -1)
-    assert.ok(captureStderr(callprop).indexOf(' deprecated ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+    assert.notStrictEqual(stderr.indexOf(' propa gone '), -1)
+    assert.notStrictEqual(captureStderr(callprop).indexOf(' deprecated '), -1)
     assert.strictEqual(val, 'newval')
   })
 
@@ -450,7 +450,7 @@ describe('deprecate.property(obj, prop, message)', function () {
 
     var stderr = captureStderr(callold)
     var fileline = stderr.match(/\.js:[0-9]+:/)
-    assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+    assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
     assert.strictEqual(stderr.split('deprecated').length, 3)
     assert.strictEqual(stderr.split(fileline[0]).length, 3)
   })
@@ -458,14 +458,14 @@ describe('deprecate.property(obj, prop, message)', function () {
   it('should show call site outside scope', function () {
     function callold () { mylib.layerprop() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(' propa ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' propa '), -1)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
   it('should show call site outside scope from strict lib', function () {
     function callold () { strictlib.layerprop() }
     var stderr = captureStderr(callold)
-    assert.ok(stderr.indexOf(' propa ') !== -1)
+    assert.notStrictEqual(stderr.indexOf(' propa '), -1)
     assert.ok(/test.js:[0-9]+:[0-9]+/.test(stderr))
   })
 
@@ -473,30 +473,30 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access to property on function', function () {
       function callprop () { return mylib.fnprop.propa }
       var stderr = captureStderr(callprop)
-      assert.ok(stderr.indexOf(' deprecated ') !== -1)
-      assert.ok(stderr.indexOf(' fn propa gone ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+      assert.notStrictEqual(stderr.indexOf(' fn propa gone '), -1)
     })
 
     it('should generate message on named function', function () {
       function callprop () { return mylib.fnprop.propautomsg }
       var stderr = captureStderr(callprop)
-      assert.ok(stderr.indexOf(' deprecated ') !== -1)
-      assert.ok(stderr.indexOf(' thefn.propautomsg ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+      assert.notStrictEqual(stderr.indexOf(' thefn.propautomsg '), -1)
     })
 
     describe('in strict mode library', function () {
       it('should log on access to property on function', function () {
         function callprop () { return strictlib.fnprop.propa }
         var stderr = captureStderr(callprop)
-        assert.ok(stderr.indexOf(' deprecated ') !== -1)
-        assert.ok(stderr.indexOf(' fn propa gone ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+        assert.notStrictEqual(stderr.indexOf(' fn propa gone '), -1)
       })
 
       it('should generate message on named function', function () {
         function callprop () { return strictlib.fnprop.propautomsg }
         var stderr = captureStderr(callprop)
-        assert.ok(stderr.indexOf(' deprecated ') !== -1)
-        assert.ok(stderr.indexOf(' thefn.propautomsg ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(' deprecated '), -1)
+        assert.notStrictEqual(stderr.indexOf(' thefn.propautomsg '), -1)
       })
     })
   })
@@ -505,14 +505,14 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access and set', function () {
       function callold () { return mylib.propa }
       function setold () { mylib.propa = 'val' }
-      assert.ok(captureStderr(callold).indexOf(' deprecated ') !== -1)
-      assert.ok(captureStderr(setold).indexOf(' deprecated ') !== -1)
+      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
+      assert.notStrictEqual(captureStderr(setold).indexOf(' deprecated '), -1)
     })
 
     it('should not log on set to non-writable', function () {
       function callold () { return mylib.propget }
       function setold () { mylib.propget = 'val' }
-      assert.ok(captureStderr(callold).indexOf(' deprecated ') !== -1)
+      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
       assert.strictEqual(captureStderr(setold), '')
     })
   })
@@ -521,8 +521,8 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should log on access and set', function () {
       function callold () { return mylib.propdyn }
       function setold () { mylib.propdyn = 'val' }
-      assert.ok(captureStderr(callold).indexOf(' deprecated ') !== -1)
-      assert.ok(captureStderr(setold).indexOf(' deprecated ') !== -1)
+      assert.notStrictEqual(captureStderr(callold).indexOf(' deprecated '), -1)
+      assert.notStrictEqual(captureStderr(setold).indexOf(' deprecated '), -1)
     })
 
     it('should not log on access when no accessor', function () {
@@ -540,9 +540,9 @@ describe('deprecate.property(obj, prop, message)', function () {
     it('should generate message for method call on named function', function () {
       function callold () { return mylib.propauto }
       var stderr = captureStderr(callold)
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-      assert.ok(stderr.indexOf('deprecated') !== -1)
-      assert.ok(stderr.indexOf(' propauto ') !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+      assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+      assert.notStrictEqual(stderr.indexOf(' propauto '), -1)
       assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
     })
 
@@ -550,9 +550,9 @@ describe('deprecate.property(obj, prop, message)', function () {
       it('should generate message for method call on named function', function () {
         function callold () { return strictlib.propauto }
         var stderr = captureStderr(callold)
-        assert.ok(stderr.indexOf(basename(__filename)) !== -1)
-        assert.ok(stderr.indexOf('deprecated') !== -1)
-        assert.ok(stderr.indexOf(' propauto ') !== -1)
+        assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
+        assert.notStrictEqual(stderr.indexOf('deprecated'), -1)
+        assert.notStrictEqual(stderr.indexOf(' propauto '), -1)
         assert.ok(/ at [^\\/]+[^:]+test\.js:/.test(stderr))
       })
     })
@@ -683,13 +683,13 @@ describe('process.env.TRACE_DEPRECATION', function () {
   it('should trace given namespace', function () {
     var tracelib = libs.trace
     function callold () { tracelib.old() }
-    assert.ok(captureStderr(callold).indexOf(' trace-lib deprecated old\n    at callold (') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(' trace-lib deprecated old\n    at callold ('), -1)
   })
 
   it('should not trace non-given namespace', function () {
     var tracelib = libs.trace
     function callold () { tracelib.old2() }
-    assert.ok(captureStderr(callold).indexOf(' trace-lib-other deprecated old2 at ') !== -1)
+    assert.notStrictEqual(captureStderr(callold).indexOf(' trace-lib-other deprecated old2 at '), -1)
   })
 
   describe('when output supports colors', function () {
@@ -702,15 +702,15 @@ describe('process.env.TRACE_DEPRECATION', function () {
 
     it('should log in color', function () {
       assert.notStrictEqual(stderr, '')
-      assert.ok(stderr.indexOf('\x1b[') !== -1)
+      assert.notStrictEqual(stderr.indexOf('\x1b['), -1)
     })
 
     it('should log namespace', function () {
-      assert.ok(stderr.indexOf('trace-lib') !== -1)
+      assert.notStrictEqual(stderr.indexOf('trace-lib'), -1)
     })
 
     it('should log call site in color', function () {
-      assert.ok(stderr.indexOf(basename(__filename)) !== -1)
+      assert.notStrictEqual(stderr.indexOf(basename(__filename)), -1)
       assert.ok(/\x1b\[\d+mat callold \(/.test(stderr)) // eslint-disable-line no-control-regex
     })
   })
@@ -748,7 +748,7 @@ describe('node script.js', function () {
     it('should suppress deprecation message', function (done) {
       captureChildStderr(script, ['--trace-deprecation'], function (err, stderr) {
         if (err) return done(err)
-        assert.ok(stderr.indexOf('__timestamp__ my-cool-module deprecated oldfunction\n    at run (' + script + ':7:10)\n    at') === 0)
+        assert.strictEqual(stderr.indexOf('__timestamp__ my-cool-module deprecated oldfunction\n    at run (' + script + ':7:10)\n    at'), 0)
         done()
       })
     })


### PR DESCRIPTION
Using `assert.notStrictEqual(..., -1)` instead of `assert.ok(... !== -1)` and displaying `stderr` in case of assertion failure.

This commit was initially made as part of https://github.com/dougwilson/nodejs-depd/pull/48, but it could be adopted independently

The pipeline is ✔️: https://github.com/voyages-sncf-technologies/nodejs-depd/actions/runs/2004525534